### PR TITLE
fix(docker): Set correct entrypoint for Hugging Face Spaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ EXPOSE 7860
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD curl -f http://127.0.0.1:7860/health || exit 1
 
-CMD ["python", "run_fastapi.py"]
+CMD ["python", "app.py"]


### PR DESCRIPTION
The Dockerfile was previously configured to run the FastAPI application, which is not the intended entrypoint for Hugging Face Spaces.

This change updates the CMD instruction to run app.py, which is the correct Flask-based application for the Spaces environment, ensuring successful deployment.