### PR TITLE
The existing CORS configuration was too restrictive and did not allow…

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -29,16 +29,7 @@ def create_app(config_name):
         )
 
     db.init_app(app)
-    CORS(
-        app,
-        origins=[
-            "http://localhost:3000",
-            "https://painaidee.com",
-            "https://frontend-painaidee.web.app",
-        ],
-        methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-        allow_headers=["Content-Type", "Authorization"],
-    )
+    CORS(app, resources={r"/api/*": {"origins": "*"}})
     jwt = JWTManager(app)
 
     @jwt.user_lookup_loader


### PR DESCRIPTION
… requests from arbitrary frontend origins, such as Vercel deployments.

This change updates the CORS settings in `src/app.py` to use a wildcard origin (`*`) for all API routes under `/api/*`. This ensures that the backend can be accessed from any frontend client as intended.