### PR TITLE
Refactor the CORS configuration to better support different environme…

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -31,15 +31,22 @@ def create_app(config_name):
 
     db.init_app(app)
 
-    # Configure CORS, allowing origins from an environment variable.
-    # The variable should be a comma-separated list of origins.
-    # Example: "http://localhost:3000,https://my-frontend.com"
-    allowed_origins_str = os.environ.get(
-        "CORS_ALLOWED_ORIGINS",
-        "http://localhost:3000,http://127.0.0.1:3000,https://pai-naidee-ui-spark.vercel.app",
-    )
-    allowed_origins = [origin.strip() for origin in allowed_origins_str.split(",")]
-    CORS(app, resources={r"/api/*": {"origins": allowed_origins}})
+    # Configure CORS for the application.
+    # The primary production frontend is allowed by default.
+    # This can be overridden by the `CORS_ALLOWED_ORIGINS` environment variable
+    # for other environments (e.g., "http://localhost:3000,http://127.0.0.1:3000").
+    # For test mode, you can set `CORS_ALLOWED_ORIGINS=*` but be aware of the security risks.
+    default_origins = "https://pai-naidee-ui-spark.vercel.app"
+    allowed_origins_str = os.environ.get("CORS_ALLOWED_ORIGINS", default_origins)
+
+    if allowed_origins_str == "*":
+        # WARNING: Allowing all origins is a security risk.
+        # This should only be used for specific testing scenarios.
+        origins = "*"
+    else:
+        origins = [origin.strip() for origin in allowed_origins_str.split(",")]
+
+    CORS(app, resources={r"/api/*": {"origins": origins}})
     jwt = JWTManager(app)
 
     @jwt.user_lookup_loader


### PR DESCRIPTION
…nts.

The previous implementation had a hardcoded list of default origins. This change simplifies the logic by setting the production frontend ('https://pai-naidee-ui-spark.vercel.app') as the single default origin.

It preserves the ability to override the allowed origins using the `CORS_ALLOWED_ORIGINS` environment variable, which is useful for local development or other deployment scenarios. This also addresses the user's request to support a wildcard ('*') for testing purposes, with a security warning added to the code comments.