### PR TITLE
fix(attractions): Remove address field to match DB schema

### DIFF
--- a/src/models/attraction.py
+++ b/src/models/attraction.py
@@ -9,7 +9,6 @@ class Attraction(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(255), nullable=False)
     description = db.Column(db.Text)
-    address = db.Column(db.String(255))
     province = db.Column(db.String(100))
     district = db.Column(db.String(100))
     latitude = db.Column(db.Float)
@@ -39,7 +38,6 @@ class Attraction(db.Model):
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "address": self.address,
             "province": self.province,
             "district": self.district,
             "location": {"lat": self.latitude, "lng": self.longitude},

--- a/src/schemas/attraction.py
+++ b/src/schemas/attraction.py
@@ -4,7 +4,6 @@ from marshmallow import Schema, fields, validate
 class AttractionSchema(Schema):
     name = fields.Str(required=True, validate=validate.Length(min=3, max=255))
     description = fields.Str(required=True)
-    address = fields.Str()
     province = fields.Str(required=True)
     district = fields.Str()
     latitude = fields.Float()

--- a/src/services/attraction_service.py
+++ b/src/services/attraction_service.py
@@ -126,7 +126,6 @@ class AttractionService:
         new_attraction = Attraction(
             name=data.get("name"),
             description=data.get("description"),
-            address=data.get("address"),
             province=data.get("province"),
             district=data.get("district"),
             latitude=data.get("latitude"),

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -124,7 +124,6 @@ class SearchService:
             ("province", attraction.province, 0.7),
             ("district", attraction.district, 0.6),
             ("category", attraction.category, 0.9),
-            ("address", attraction.address, 0.5),
         ]
         
         for field_name, field_value, weight in search_fields:


### PR DESCRIPTION
Removes the `address` field from the `Attraction` model, schema, and related services.

This field was present in the application code but does not exist in the Supabase database schema for the `attractions` table, causing `psycopg2.errors.UndefinedColumn` errors when querying for attractions.

The following changes were made:
- Removed `address` from `src/models/attraction.py`
- Removed `address` from `src/schemas/attraction.py`
- Removed `address` from `src/services/attraction_service.py`
- Removed `address` from `src/services/search_service.py`

This change resolves the database error and allows the attractions API and search functionality to work correctly.