### PR TITLE
feat: Implement automatic database setup on startup

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -44,6 +44,7 @@ class Settings(BaseSettings):
     app_name: str = "PaiNaiDee Backend API - Phase 1"
     version: str = "1.0.0"
     debug: bool = Field(default=False, env="DEBUG")
+    attractions_json_path: str = Field(default="attractions_cleaned_ready.json", env="ATTRACTIONS_JSON_PATH")
     
     # CORS
     cors_origins: List[str] = Field(

--- a/app/db/seeding.py
+++ b/app/db/seeding.py
@@ -1,0 +1,78 @@
+import json
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.core.logging import logger
+from app.db.models import Location, Post, PostMedia
+from app.core.config import settings
+
+async def seed_data(db: AsyncSession):
+    """
+    Seeds the database with initial data from a JSON file if the database is empty.
+    """
+    logger.log_event("db.seeding.check", {"message": "Checking if database needs seeding."})
+
+    # 1. Check if Locations table is empty
+    result = await db.execute(select(Location))
+    if result.scalars().first() is not None:
+        logger.log_event("db.seeding.skipped", {"message": "Database already seeded."})
+        return
+
+    logger.log_event("db.seeding.start", {"message": "Database is empty. Seeding data..."})
+
+    # 2. Load data from JSON file
+    try:
+        with open(settings.attractions_json_path, "r", encoding="utf-8-sig") as f:
+            attractions = json.load(f)
+        logger.log_event("db.seeding.load_json.success", {"count": len(attractions), "path": settings.attractions_json_path})
+    except FileNotFoundError:
+        logger.log_event("db.seeding.load_json.failed", {"error": "File not found", "path": settings.attractions_json_path})
+        return
+    except json.JSONDecodeError:
+        logger.log_event("db.seeding.load_json.failed", {"error": "JSON decode error", "path": settings.attractions_json_path})
+        return
+
+    # 3. Create and add new objects to the session
+    for attraction in attractions:
+        # Create Location
+        new_location = Location(
+            name=attraction.get("name"),
+            province=attraction.get("province"),
+            lat=attraction.get("latitude") or 0.0,
+            lng=attraction.get("longitude") or 0.0,
+            popularity_score=0 # Default value
+        )
+        db.add(new_location)
+        await db.flush() # Flush to get the new_location.id
+
+        # Create Post
+        new_post = Post(
+            user_id="system_generated", # Placeholder user
+            caption=attraction.get("description", ""),
+            location_id=new_location.id,
+            lat=new_location.lat,
+            lng=new_location.lng,
+            tags=[attraction.get("category")] if attraction.get("category") else []
+        )
+        db.add(new_post)
+        await db.flush() # Flush to get the new_post.id
+
+        # Create PostMedia
+        image_urls = attraction.get("image_urls", [])
+        if image_urls and isinstance(image_urls, list) and "value" in image_urls[0]:
+             for i, url in enumerate(image_urls[0]["value"]):
+                new_media = PostMedia(
+                    post_id=new_post.id,
+                    media_type="image",
+                    url=url,
+                    ordering=i
+                )
+                db.add(new_media)
+
+
+    # 4. Commit the transaction
+    try:
+        await db.commit()
+        logger.log_event("db.seeding.commit.success", {"message": "Successfully seeded database."})
+    except Exception as e:
+        logger.log_event("db.seeding.commit.failed", {"error": str(e)})
+        await db.rollback()

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -2,7 +2,9 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+
 from app.core.config import settings
+from app.core.logging import logger
 
 # Synchronous database setup (for migrations)
 sync_engine = create_engine(settings.database_uri)
@@ -36,20 +38,39 @@ async def get_async_db():
         yield session
 
 
+from app.db.seeding import seed_data
+
 async def init_db():
-    """Initialize database with extensions"""
-    async with async_engine.begin() as conn:
-        # Only run PostgreSQL-specific commands if using PostgreSQL
-        if "postgresql" in settings.database_uri:
-            # Enable pg_trgm extension for fuzzy search
-            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm;"))
-            
-            # Enable PostGIS if available (optional)
-            try:
-                await conn.execute(text("CREATE EXTENSION IF NOT EXISTS postgis;"))
-            except Exception:
-                # PostGIS not available, will use lat/lng columns instead
-                pass
-        else:
-            # For SQLite, we'll use simple text matching instead of pg_trgm
-            pass
+    """Initialize database, create tables, and seed initial data."""
+    logger.log_event("db.init.start", {"message": "Starting database initialization..."})
+    from app.db.models import Base
+
+    try:
+        # Use a connection with autocommit for creating extensions
+        async with async_engine.connect() as conn:
+            if "postgresql" in settings.database_uri:
+                await conn.execute(text("COMMIT")) # Ensure no transaction is active
+                logger.log_event("db.init.extensions.start", {"db_type": "postgresql"})
+                await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm;"))
+                try:
+                    await conn.execute(text("CREATE EXTENSION IF NOT EXISTS postgis;"))
+                    logger.log_event("db.init.extensions.success", {"extensions": ["pg_trgm", "postgis"]})
+                except Exception as e:
+                    logger.log_event("db.init.extensions.warning", {"message": f"PostGIS not available: {e}"})
+
+        # Now create tables in a new transaction
+        async with async_engine.begin() as conn:
+            logger.log_event("db.init.create_all.start", {})
+            await conn.run_sync(Base.metadata.create_all)
+            logger.log_event("db.init.create_all.success", {})
+
+        # Seed data
+        logger.log_event("db.seeding.start", {})
+        async with AsyncSessionLocal() as db_session:
+            await seed_data(db_session)
+
+        logger.log_event("db.init.finish", {"message": "Database initialization and seeding completed successfully."})
+
+    except Exception as e:
+        logger.log_event("db.init.failed", {"error": str(e)})
+        raise


### PR DESCRIPTION
This commit introduces a mechanism to automatically initialize the database when the backend application starts.

The changes include:
- A new `app/db/seeding.py` module with logic to seed the database from a JSON file.
- The `init_db` function in `app/db/session.py` is updated to:
    - Create necessary PostgreSQL extensions (`pg_trgm`, `postgis`).
    - Create all tables based on SQLAlchemy models if they don't exist.
    - Call the seeding logic to populate the database with initial data if it's empty.
- Added structured logging for the entire database setup process.
- Added a configuration for the seeding data file path.
- Fixed a bug in the seeding script to handle JSON files with a BOM.