### PR TITLE
Configure CORS and add health checks for Flask and FastAPI

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -54,9 +54,18 @@ class Settings(BaseSettings):
 
     @field_validator("cors_origins", mode="before")
     def assemble_cors_origins(cls, v: str | List[str]) -> List[str]:
+        origins = []
         if isinstance(v, str):
-            return [origin.strip() for origin in v.split(",")]
-        return v
+            origins = [origin.strip() for origin in v.split(",")]
+        elif isinstance(v, list):
+            origins = v
+
+        # Ensure the required Vercel domain is always present for the frontend
+        required_origin = "https://pai-naidee-ui-spark.vercel.app"
+        if required_origin not in origins:
+            origins.append(required_origin)
+
+        return origins
     
     # Pydantic v2 configuration
     model_config = SettingsConfigDict(

--- a/app/main.py
+++ b/app/main.py
@@ -125,6 +125,11 @@ This implementation focuses on:
     async def health_check():
         """Simple health check endpoint"""
         return {"status": "ok", "message": "Backend is running"}
+
+    @app.get("/api/health", tags=["health"])
+    async def api_health_check():
+        """Simple health check endpoint for API gateway"""
+        return {"status": "ok", "message": "API is running"}
     
     return app
 

--- a/src/app.py
+++ b/src/app.py
@@ -41,7 +41,9 @@ def create_app(config_name):
                 "http://localhost:3000",
                 "https://pai-naidee-ui-spark.vercel.app",
                 "https://athipan01-painaidee-backend.hf.space"
-            ]
+            ],
+            "methods": ["*"],
+            "allow_headers": ["*"]
         }
     })
     print("🚀 CORS origins allowed:",


### PR DESCRIPTION
This commit addresses the user's request to configure the backend for frontend integration.

- **Flask CORS (`src/app.py`):**
  - Updated the CORS configuration to correctly use `allow_headers=["*"]` and `methods=["*"]`.
  - The allowed origins list already included the required Vercel domain.

- **FastAPI CORS (`app/core/config.py`):**
  - Made the CORS configuration more robust by programmatically ensuring the Vercel domain (`https://pai-naidee-ui-spark.vercel.app`) is always included in the list of allowed origins, regardless of environment variables.

- **FastAPI Health Check (`app/main.py`):**
  - Added a new health check endpoint at `GET /api/health` as requested, complementing the existing `/health` endpoint.

These changes ensure that both backend applications are correctly configured to accept requests from the specified Vercel frontend and provide the necessary health check endpoints.