### PR TITLE
refactor: Move CORS configuration to config file

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -34,23 +34,14 @@ def create_app(config_name):
 
     db.init_app(app)
 
-    # Define allowed origins for CORS
-    allowed_origins = [
-        "http://127.0.0.1:3000",
-        "http://localhost:3000",
-        "https://pai-naidee-ui-spark.vercel.app",
-        "https://athipan01-painaidee-backend.hf.space",
-    ]
-
     CORS(app, resources={
         r"/api/*": {
-            "origins": allowed_origins,
+            "origins": app.config.get("CORS_ORIGINS", []),
             "methods": ["*"],
             "allow_headers": ["*"]
         }
     })
 
-    print("🚀 CORS origins allowed:", allowed_origins)
     jwt = JWTManager(app)
 
     @jwt.user_lookup_loader

--- a/src/config.py
+++ b/src/config.py
@@ -8,6 +8,12 @@ class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY") or "you-will-never-guess"
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     MAX_CONTENT_LENGTH = 50 * 1024 * 1024  # 50MB max file size
+    CORS_ORIGINS = [
+        "http://127.0.0.1:3000",  # Local development
+        "http://localhost:3000",  # Local development
+        "https://pai-naidee-ui-spark.vercel.app",  # Vercel frontend
+        "https://athipan01-painaidee-backend.hf.space",  # Hugging Face Space
+    ]
 
 
 class DevelopmentConfig(Config):


### PR DESCRIPTION
- Moves the list of allowed CORS origins from src/app.py to src/config.py to centralize configuration.
- Updates src/app.py to read the CORS origins from the configuration.
- This change ensures that the frontend at https://pai-naidee-ui-spark.vercel.app is an allowed origin and triggers a redeployment of the Hugging Face Space.