### PR TITLE
feat: add ngrok to CORS allowed origins

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -73,6 +73,7 @@ class Settings(BaseSettings):
         required_origins = {
             "https://pai-naidee-ui-spark.vercel.app",
             "http://localhost:3000",
+            "https://a75aab886190.ngrok-free.app",      # URL ที่ ngrok สร้างขึ้น
         }
 
         origins.update(required_origins)


### PR DESCRIPTION
This change adds the ngrok URL to the list of required CORS origins in the application settings.

This allows the frontend, when accessed via an ngrok tunnel, to communicate with the backend API during development and testing.